### PR TITLE
Remove pinning of unreleased Avocado

### DIFF
--- a/.github/workflows/modules-tests.yml
+++ b/.github/workflows/modules-tests.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Avocado to run tests
-        run: pip3 install git+https://github.com/avocado-framework/avocado@7998c0a6d1bdd8ce60235cd4d2aa04afbebfe00e#egg=avocado_framework
+        run: pip3 install avocado-framework==102.0
 
       - name: Run the ar module test
         run: ./tests/test-module.py metadata/autils/archive/ar.yml

--- a/tests/test-module.py
+++ b/tests/test-module.py
@@ -22,10 +22,6 @@ for platform in metadata["supported_platforms"]:
     image = CONTAINER_IMAGE_MAPPING.get(platform)
     config = {"run.spawner": "podman", "spawner.podman.image": image}
 
-    # REMOVE when Avocado 102.0 is released
-    config[
-        "spawner.podman.avocado_spawner_egg"
-    ] = "https://cleber.fedorapeople.org/avocado_framework-101.0-py3.11.egg"
     config["resolver.references"] = metadata["tests"]
     test_suites.append(TestSuite.from_config(config, name))
 


### PR DESCRIPTION
Some functionality (like the test .data support) was needed on autils but not (then) yet available on a released Avocado version.

Now with 102.0 out, it's possible to use it without special gimmicks.