### PR TITLE
Add static check with "avocado-static-checks"

### DIFF
--- a/.github/workflows/modules-tests.yml
+++ b/.github/workflows/modules-tests.yml
@@ -16,3 +16,17 @@ jobs:
 
       - name: Run the ar module test
         run: ./tests/test-module.py metadata/autils/archive/ar.yml
+
+  static-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Install requirements for the static checks
+        run: pip3 install -r static-checks/requirements.txt
+
+      - name: Runs all the static checks
+        run: ./static-checks/run-static-checks

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "avocado-static-checks"]
+	path = static-checks
+	url = ../avocado-static-checks
+	branch = main


### PR DESCRIPTION
Adds a Python module import order check.

This is based on "avocado-static-checks", which is being added here as a submodule.  The idea is to use the same checks in all "avocado-framework" projects without having to maintain different versions of the static check code/wrappers.