### PR TITLE
Use avocado-ci-tools for static-checks

### DIFF
--- a/.github/workflows/modules-tests.yml
+++ b/.github/workflows/modules-tests.yml
@@ -22,11 +22,8 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
+
+      - name: run static checks
+        uses: avocado-framework/avocado-ci-tools@main
         with:
-          submodules: true
-
-      - name: Install requirements for the static checks
-        run: pip3 install -r static-checks/requirements.txt
-
-      - name: Runs all the static checks
-        run: ./static-checks/run-static-checks
+          avocado-static-checks: true


### PR DESCRIPTION
It uses avocado-ci-tools/static-checks for running avocado-static-checks instead directly dunning scripts from avocado-static-checks repo.