### PR TITLE
Add Python code lint check

### DIFF
--- a/.github/workflows/modules-tests.yml
+++ b/.github/workflows/modules-tests.yml
@@ -15,13 +15,16 @@ jobs:
         run: pip3 install 'avocado-framework<104.0'
 
       - name: Run the ar module test
-        run: ./tests/test-module.py metadata/autils/archive/ar.yml
+        run: ./tests/test_module.py metadata/autils/archive/ar.yml
 
   static-checks:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
+
+      - name: Install Avocado to allow for lint check on Python code under tests directory
+        run: pip3 install 'avocado-framework<104.0'
 
       - name: run static checks
         uses: avocado-framework/avocado-ci-tools@main

--- a/.github/workflows/modules-tests.yml
+++ b/.github/workflows/modules-tests.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Avocado to run tests
-        run: pip3 install avocado-framework==102.0
+        run: pip3 install 'avocado-framework<104.0'
 
       - name: Run the ar module test
         run: ./tests/test-module.py metadata/autils/archive/ar.yml

--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -12,4 +12,4 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Validating all libraries against our schema
-        run: python3 tests/validate-schema.py
+        run: python3 tests/validate_schema.py

--- a/autils/archive/ar.py
+++ b/autils/archive/ar.py
@@ -80,8 +80,8 @@ class Ar:
                 member = struct.unpack(
                     FILE_HEADER_FMT, open_file.read(FILE_HEADER_SIZE)
                 )
-            except struct.error:
-                raise StopIteration
+            except struct.error as exc:
+                raise StopIteration from exc
 
             # No support for extended file names
             identifier = member[0].decode("ascii").strip()
@@ -105,3 +105,4 @@ class Ar:
                 with self as open_file:
                     open_file.seek(member.offset)
                     return open_file.read(member.size)
+        return None

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -12,8 +12,8 @@ CONTAINER_IMAGE_MAPPING = {
     "Fedora 37": "fedora:37",
 }
 
-metadata_path = sys.argv[1]
-with open(metadata_path, "rb") as m:
+METADATA_PATH = sys.argv[1]
+with open(METADATA_PATH, "rb") as m:
     metadata = yaml.load(m, Loader=yaml.SafeLoader)
 
 test_suites = []

--- a/tests/validate_schema.py
+++ b/tests/validate_schema.py
@@ -39,6 +39,7 @@ def validate_yaml(filename, schema):
 
 
 def validate_yamls():
+    """Validates all yamls in the repo against the autils schema."""
     print("Starting validation...")
     failed = False
     for file in glob.glob("./metadata/autils/*/*.yml"):
@@ -53,6 +54,7 @@ def validate_yamls():
         return 1
 
     print("All files passed validation.")
+    return 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This updates the avocado-static-check submodule, and implements the changes necessary to have the lint checks passing.