### PR TITLE
API Stability

### DIFF
--- a/.github/workflows/modules-tests.yml
+++ b/.github/workflows/modules-tests.yml
@@ -30,3 +30,30 @@ jobs:
         uses: avocado-framework/avocado-ci-tools@main
         with:
           avocado-static-checks: true
+
+
+  api-stability-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Autils code from PR
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Fetch main branch
+        run: git fetch origin main
+
+      - name: Check for changes in tests directory
+        id: test_changes
+        run: |
+          git diff --quiet origin/main -- tests/
+        continue-on-error: true
+
+      - name: Install Avocado to run tests
+        if: steps.test_changes.outcome == 'failure'
+        run: pip3 install 'avocado-framework<104.0'
+
+      - name: Run API stability tests
+        if: steps.test_changes.outcome == 'failure'
+        run: ./tests/test_module.py metadata/autils/archive/ar.yml
+


### PR DESCRIPTION
Autils code is fetched from the pull request using the github.event.pull_request.head.sha. The tests are fetched from the master branch by running git fetch origin master and checking out only the tests/ directory from the master branch.

Reference:      https://github.com/avocado-framework/autils/issues/23