### PR TITLE
Autils release process

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,6 +1,7 @@
 name: Pre-Release
-on: workflow_dispatch
-
+on:
+  workflow_dispatch:
+  workflow_call:
 jobs:
 
   release-test:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,57 @@
+name: Pre-Release
+on: workflow_dispatch
+
+jobs:
+
+  release-test:
+    name: Pre-Release pipeline
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:34
+
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@021a2405c7f990db57f5eae5397423dcc554159c
+        with:
+          app_id: ${{ secrets.MR_AVOCADO_ID }}
+          installation_id: ${{ secrets.MR_AVOCADO_INSTALLATION_ID }}
+          private_key: ${{ secrets.MR_AVOCADO_PRIVATE_KEY }}
+      - name: install required packages
+        run:  dnf -y install git python3-pip
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Build wheel
+        run: |
+          git config --global --add safe.directory "*"
+          python3 -m pip install build
+          mkdir PYPI_UPLOAD
+          python3 -m build -o PYPI_UPLOAD
+      - name: Save wheel as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheel
+          path: ${{github.workspace}}/PYPI_UPLOAD/
+          retention-days: 3
+
+  publish-to-test-pypi:
+    name: Publish Avocado to TestPyPI
+    needs:
+    - release-test
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://test.pypi.org/project/autils
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    steps:
+    - name: Download all the wheels
+      uses: actions/download-artifact@v4
+      with:
+        name: wheel
+        path: dist/
+    - name: Publish avocado to test PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/release-bot.yml
+++ b/.github/workflows/release-bot.yml
@@ -7,6 +7,8 @@ jobs:
   release-vote:
     name: release vote
     runs-on: ubuntu-20.04
+    outputs:
+      release: ${{ steps.vote_count.outputs.release }}
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
@@ -82,6 +84,7 @@ jobs:
           fi
       - name: Count votes
         if: ${{ env.TIME_FOR_VOTE == 1 }}
+        id: vote_count
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
@@ -125,6 +128,7 @@ jobs:
               }'
               echo "It is time for release."
               echo 'TIME_FOR_RELEASE=1' >> $GITHUB_ENV
+              echo "release=1" >> "$GITHUB_OUTPUT"
             else
               echo "We don't have enought votes."
             fi
@@ -151,9 +155,12 @@ jobs:
             }
             '
           fi
-      - name: Release
-        if: ${{ env.TIME_FOR_RELEASE == 1 }}
-        env:
-          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
-        run: |
-          echo 'RELEASE'
+  pre-release:
+    needs: release-vote
+    secrets: inherit
+    if: ${{ needs.release-vote.outputs.release == 1 }}
+    uses: ./.github/workflows/pre-release.yml
+  release:
+    needs: pre-release
+    secrets: inherit
+    uses: ./.github/workflows/release.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,82 @@
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version type'
+        type: choice
+        options:
+        - major
+        - minor
+        default: 'major'
+  workflow_call:
+
+jobs:
+
+  release:
+    name: Release pipeline
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:34
+    env:
+      VERSION: ${{ github.event.inputs.version }}
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@021a2405c7f990db57f5eae5397423dcc554159c
+        with:
+          app_id: ${{ secrets.MR_AVOCADO_ID }}
+          installation_id: ${{ secrets.MR_AVOCADO_INSTALLATION_ID }}
+          private_key: ${{ secrets.MR_AVOCADO_PRIVATE_KEY }}
+      - name: install required packages
+        run:  dnf -y install git python3-pip
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Commit files and tag
+        run: |
+          git config --global --add safe.directory "*"
+          git config --global user.name mr-avocado
+          git config --global user.email "username@users.noreply.github.com"
+          if [[ ${{ env.VERSION }} = "major" ]]; then
+            version=$(git tag --sort=version:refname | tail -n 1 | awk -F. '{$1++; $2=0; print $1"."$2}')
+          else
+            version=$(git tag --sort=version:refname | tail -n 1 | awk -F. '{$1; $2++; print $1"."$2}')
+          fi
+          git tag "$version" -m "Release $version"
+      - name: Push changes to github
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ steps.generate_token.outputs.token }}
+          branch: ${{ github.ref }}
+      - name: Build wheel
+        run: |
+          python3 -m pip install build
+          mkdir PYPI_UPLOAD
+          python3 -m build -o PYPI_UPLOAD
+      - name: Save wheel as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheel
+          path: ${{github.workspace}}/PYPI_UPLOAD/
+          retention-days: 3
+
+  publish-to-pypi:
+    name: Publish Avocado to PyPI
+    needs:
+    - release
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/autils
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    steps:
+    - name: Download all the wheels
+      uses: actions/download-artifact@v4
+      with:
+        name: wheel
+        path: dist/
+    - name: Publish avocado to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,37 @@
+[build-system]
+requires = ["setuptools>=64", "setuptools-scm>=8"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "autils"
+dynamic = ["version"]
+requires-python = ">=3.7"
+authors = [
+  {name = "Cleber Rosa", email = "crosa@redhat.com"},
+  {name = "Harvey James Lynden", email = "hlynden@redhat.com"},
+  {name = "Jan Richter", email = "jarichte@redhat.com"},
+]
+maintainers = [
+  {name = "Cleber Rosa", email = "crosa@redhat.com"},
+  {name = "Harvey James Lynden", email = "hlynden@redhat.com"},
+  {name = "Jan Richter", email = "jarichte@redhat.com"},
+]
+description = "Utility Libraries to power your tests (or general applications)"
+readme = "README.md"
+license = {file = "LICENSE"}
+keywords = ["Avocado", "testing", "utility", "library", "test"]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Programming Language :: Python",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
+  "Topic :: Software Development :: Testing"
+]
+[project.urls]
+Homepage = "https://avocado-framework.github.io/autils.html"
+Repository = "https://github.com/avocado-framework/autils"
+
+[tool.setuptools]
+packages = ["autils"]
+
+[tool.setuptools_scm]


### PR DESCRIPTION
This PR introduces the release workflow for autils. The release workflow can be triggered manually, or it will be triggered by release-bot after successful voting. The release workflow supports a manual trigger for creating minor version releases, which can be used for security updates or critical fixes.

The PR also introduces pre-release workflow which uses `test.pypi` to run the dry-run of the release to check release process.

Before the first release, we need to configure the `test.pypi` and `pypi` instances and create `0.0` tag to make this fully operational.

Test of the release workflow:
https://github.com/richtja/autils/actions/runs/11840187779/job/32993407763

Test of the pre-release workflow:
https://github.com/richtja/autils/actions/runs/11841451279

Test of the release-bot:
https://github.com/richtja/autils/actions/runs/11856687960