### PR TITLE
Testpypi environment for pre-release workflow

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -42,7 +42,7 @@ jobs:
     - release-test
     runs-on: ubuntu-latest
     environment:
-      name: pypi
+      name: testpypi
       url: https://test.pypi.org/project/autils
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing


### PR DESCRIPTION
This commit changes the pypi environment for pre-release workflow. With this change, we can apply different deployment rules to pre-release and release without touching the code.