### PR TITLE
repository name fix in release_bot

### DIFF
--- a/.github/workflows/release-bot.yml
+++ b/.github/workflows/release-bot.yml
@@ -37,7 +37,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
           discussion_data=$(gh api graphql -f query='{
-                      search(first: 100, query: "repo:richtja/autils is:open category:Release-decision", type: DISCUSSION) {
+                      search(first: 100, query: "repo:avocado-framework/autils is:open category:Release-decision", type: DISCUSSION) {
                         nodes {
                           ... on Discussion {
                             id createdAt


### PR DESCRIPTION
There is a typo in release bot workflow which points to the wrong repo. This typo was caused by testing the release-bot functionality in the fork.